### PR TITLE
post.html: update "Submit a pull request!" link to real page

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,7 +21,7 @@ layout: default
     {% endif %}
     <h4>Published {{ page.date | date: '%B %d, %Y' }}</h4>
     <h5>
-        Found something wrong? <a href="https://github.com/mlerner/mlerner.github.io">Submit a pull request!</a>
+        Found something wrong? <a href="{{ site.github.repository_url }}/edit/HEAD/{{ page.relative_path }}">Submit a pull request!</a>
     </h5>
     <section>
         {{ content }}
@@ -50,6 +50,6 @@ layout: default
         </footer>
     </section>
     <section>
-        Found something wrong? <a href="https://github.com/mlerner/mlerner.github.io">Submit a pull request!</a>
+        Found something wrong? <a href="{{ site.github.repository_url }}/edit/HEAD/{{ page.relative_path }}">Submit a pull request!</a>
     </section>
 </article>


### PR DESCRIPTION
When a visitor clicks the link "Submit a pull request!", the link will bring them to the GitHub web editor for the given file.

Currently, clicking "Submit a pull request!" means you need to know how to navigate a Jekyll site. Most folks don't know how to! So this updates your links to open the editor for the correct page directly.

Thanks, @mlerner!